### PR TITLE
Feat: 프로젝트 주소 입력 페이지 및 공통 컴포넌트 모듈화

### DIFF
--- a/src/components/NewProject/index.jsx
+++ b/src/components/NewProject/index.jsx
@@ -2,14 +2,19 @@
 
 import { useEffect, useState } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
+import styled, { css } from "styled-components";
 
 import Modal from "../shared/Modal";
 import Welcome from "../Welcome";
+import Title from "../shared/Title";
+import Input from "../shared/Input";
+import Footer from "../shared/Footer";
 
 import { getToken } from "../../services/auth";
 
 function NewProject() {
   const [isModalOpened, setIsModalOpened] = useState(true);
+  const [inputValue, setInputValue] = useState("");
   const navigate = useNavigate();
   const [query] = useSearchParams();
 
@@ -50,16 +55,64 @@ function NewProject() {
     setIsModalOpened(false);
   }
 
+  const handleInputChange = ev => {
+    setInputValue(ev.target.value);
+  };
+
+  const handleSubmitInputValue = ev => {
+    ev.preventDefault();
+
+    navigate("/version");
+  };
+
+  const contents = {
+    title: {
+      step: "01",
+      firstSentence: "디자인 변경사항을 확인할",
+      secondSentence: "피그마 프로젝트 URL을 입력해주세요.",
+    },
+    inputInfo: {
+      id: "project",
+      label: "피그마 프로젝트 URL 입력",
+      inputs: [
+        {
+          id: "address",
+          placeholder: "url 주소를 입력해주세요. (예: www.figma.com/abc)",
+        },
+      ],
+    },
+    buttons: [
+      { text: "다음", usingCase: "solid", handleClick: handleSubmitInputValue },
+    ],
+  };
+
   return (
-    <>
-      <h1>hello</h1>
+    <StyledContent>
       {isModalOpened && (
         <Modal>
           <Welcome handleClick={handleClick} />
         </Modal>
       )}
-    </>
+      <div className="content">
+        <Title title={contents.title} />
+        <Input
+          inputInfo={contents.inputInfo}
+          onInputChange={handleInputChange}
+        />
+      </div>
+      <Footer buttons={contents.buttons} />
+    </StyledContent>
   );
 }
+
+const StyledContent = styled.div`
+  .content {
+    box-sizing: border-box;
+
+    width: 100%;
+    height: 100%;
+    padding: 64px;
+  }
+`;
 
 export default NewProject;

--- a/src/components/ProjectPage/index.jsx
+++ b/src/components/ProjectPage/index.jsx
@@ -1,21 +1,39 @@
 import { useState } from "react";
+import styled from "styled-components";
 
 import Modal from "../shared/Modal";
 import Loading from "../shared/Loading";
+import Title from "../shared/Title";
+import Select from "../shared/Select";
+import Footer from "../shared/Footer";
 
 function ProjectPage() {
   const [isLoaded, setIsLoaded] = useState(true);
 
   return (
-    <>
-      <h1>ProjectPage</h1>
+    <StyledContent>
       {!isLoaded && (
         <Modal>
           <Loading />
         </Modal>
       )}
-    </>
+      <div className="content">
+        <Title />
+        <Select />
+      </div>
+      <Footer />
+    </StyledContent>
   );
 }
+
+const StyledContent = styled.div`
+  .content {
+    box-sizing: border-box;
+
+    width: 100%;
+    height: 100%;
+    padding: 64px;
+  }
+`;
 
 export default ProjectPage;

--- a/src/components/ProjectVersion/index.jsx
+++ b/src/components/ProjectVersion/index.jsx
@@ -1,5 +1,31 @@
+import React from "react";
+import styled from "styled-components";
+
+import Title from "../shared/Title";
+import Select from "../shared/Select";
+import Footer from "../shared/Footer";
+
 function ProjectVersion() {
-  return <h1>ProjectVersion</h1>;
+  return (
+    <StyledContent>
+      <div className="content">
+        <Title />
+        <Select />
+        <Select />
+      </div>
+      <Footer />
+    </StyledContent>
+  );
 }
+
+const StyledContent = styled.div`
+  .content {
+    box-sizing: border-box;
+
+    width: 100%;
+    height: 100%;
+    padding: 64px;
+  }
+`;
 
 export default ProjectVersion;

--- a/src/components/shared/Footer.jsx
+++ b/src/components/shared/Footer.jsx
@@ -1,0 +1,36 @@
+import styled, { css } from "styled-components";
+
+import Button from "./Button";
+
+function Footer({ buttons }) {
+  return (
+    <StyledFooter>
+      {buttons.map(button => (
+        <Button
+          key={button.text}
+          onClick={button.handleClick}
+          size="medium"
+          usingCase={button.usingCase}
+        >
+          {button.text}
+        </Button>
+      ))}
+    </StyledFooter>
+  );
+}
+
+const StyledFooter = styled.footer`
+  box-sizing: border-box;
+  position: absolute;
+  bottom: 0px;
+
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: flex-end;
+  padding: 24px 40px;
+  border-top: 2px solid;
+`;
+
+export default Footer;

--- a/src/components/shared/Footer.jsx
+++ b/src/components/shared/Footer.jsx
@@ -1,4 +1,4 @@
-import styled, { css } from "styled-components";
+import styled from "styled-components";
 
 import Button from "./Button";
 
@@ -8,7 +8,7 @@ function Footer({ buttons }) {
       {buttons.map(button => (
         <Button
           key={button.text}
-          onClick={button.handleClick}
+          handleClick={button.handleClick}
           size="medium"
           usingCase={button.usingCase}
         >

--- a/src/components/shared/Input.jsx
+++ b/src/components/shared/Input.jsx
@@ -1,0 +1,50 @@
+import styled from "styled-components";
+
+function Input({ inputInfo, onInputChange }) {
+  return (
+    <StyledInput>
+      <label htmlFor={inputInfo.id}>{inputInfo.label}</label>
+      {inputInfo.inputs.map(input => (
+        <input
+          key={input.id}
+          id={input.id}
+          placeholder={input.placeholder}
+          onChange={onInputChange}
+        />
+      ))}
+      {inputInfo.description && <span>{inputInfo.description}</span>}
+    </StyledInput>
+  );
+}
+
+const StyledInput = styled.div`
+  box-sizing: border-box;
+  padding-top: 48px;
+
+  input {
+    width: 560px;
+    height: 64px;
+    padding: 0px 24px;
+    display: flex;
+
+    font-size: 1rem;
+    font-style: normal;
+    font-weight: 500;
+    line-height: 28px;
+    border-radius: 8px;
+    border: 2px solid #000000;
+    background-color: #ffffff;
+  }
+
+  label {
+    display: block;
+    margin-bottom: 12px;
+
+    font-size: 1rem;
+    font-style: normal;
+    font-weight: 700;
+    line-height: 24px;
+  }
+`;
+
+export default Input;

--- a/src/components/shared/Select.jsx
+++ b/src/components/shared/Select.jsx
@@ -1,0 +1,58 @@
+import styled from "styled-components";
+
+function Select({ selectInfo, onInputChange }) {
+  return (
+    <StyledSelect>
+      <label htmlFor={selectInfo.id}>{selectInfo.label}</label>
+      {selectInfo.selects.map(select => (
+        <select
+          key={select.id}
+          id={select.id}
+          onChange={ev => onInputChange(select.id, ev.target.value)}
+        >
+          {select.options.map(option => (
+            <option
+              key={option.value}
+              value={option.value}
+              defaultValue={option.defaultValue === option.value}
+            >
+              {option.text}
+            </option>
+          ))}
+        </select>
+      ))}
+    </StyledSelect>
+  );
+}
+
+const StyledSelect = styled.div`
+  box-sizing: border-box;
+  padding-top: 48px;
+
+  select {
+    width: 400px;
+    height: 64px;
+    padding: 0px 24px;
+    display: flex;
+
+    font-size: 1rem;
+    font-style: normal;
+    font-weight: 500;
+    line-height: 28px;
+    border-radius: 8px;
+    border: 2px solid #000000;
+    background-color: #ffffff;
+  }
+
+  label {
+    display: block;
+    margin-bottom: 12px;
+
+    font-size: 1rem;
+    font-style: normal;
+    font-weight: 700;
+    line-height: 24px;
+  }
+`;
+
+export default Select;

--- a/src/components/shared/Select.jsx
+++ b/src/components/shared/Select.jsx
@@ -14,9 +14,9 @@ function Select({ selectInfo, onInputChange }) {
             <option
               key={option.value}
               value={option.value}
-              defaultValue={option.defaultValue === option.value}
+              defaultValue={option.defaultValue}
             >
-              {option.text}
+              {option.value}
             </option>
           ))}
         </select>

--- a/src/components/shared/Title.jsx
+++ b/src/components/shared/Title.jsx
@@ -1,0 +1,34 @@
+import styled, { css } from "styled-components";
+
+function Title({ title }) {
+  return (
+    <StyledTitle>
+      <h2 className="step">STEP {title.step}</h2>
+      <h2 className="title">
+        {title.firstSentence}
+        <br />
+        {title.secondSentence}
+      </h2>
+    </StyledTitle>
+  );
+}
+
+const StyledTitle = styled.div`
+  h2 {
+    font-size: 2rem;
+    font-style: normal;
+    font-weight: 900;
+    line-height: 48px;
+    text-align: left;
+  }
+
+  .step {
+    color: #2623fb;
+  }
+
+  .title {
+    color: #000000;
+  }
+`;
+
+export default Title;

--- a/src/components/shared/Toast.jsx
+++ b/src/components/shared/Toast.jsx
@@ -30,7 +30,7 @@ const fadeInUp = keyframes`
     opacity: 0;
     transform: translateY(20px);
   }
-  
+
   to {
     opacity: 1;
     transform: translateY(0);

--- a/src/services/auth.js
+++ b/src/services/auth.js
@@ -10,7 +10,7 @@ const getAuth = () => {
   const queryParams = {
     client_id: clientId,
     redirect_uri: redirectURI,
-    scope: "file_variables:write",
+    scope: "files:read",
     state: oAuthState,
     response_type: "code",
   };


### PR DESCRIPTION
## Fix (이슈 번호)
closes #3

<br />

## 해결하려던 문제를 알려주세요!
프로젝트 주소 입력 페이지 레이아웃을 구성하고, 공통된 컴포넌트를 모듈화합니다.

<br />

## 어떻게 해결했나요?
컴포넌트를 세분화해서 분리해두었습니다. 재사용성을 고려해야하는 부분이 `Header` / Footer / Content 영역 내 사용할
Input, Select로 나누어 중복되는 화면 내 로직에 맞게 컴포넌트를 나눴습니다.

전체 화면 내 대다수 중복되는 화면 구조가 많고, 모달 내에도 동일한 레이아웃을 가지고 있습니다. 
다만 `input`, `select`가 들어가는 콘텐츠 영역에서 수행해야 하는 로직이 달라 `Input`과 `Select`는 따로 구분하여
컴포넌트화 해두었습니다.

아래 정적 컴포넌트 이미지 참고 부탁드립니다.

![component](https://github.com/Figci/Figci-Client/assets/43771772/80691d05-eb88-4389-ab3e-479c3e94c676)

<br />

## 우려사항이 있나요?(선택사항)
공통 컴포넌트 `Footer`의 경우 모달에도 재사용 가능할 지는 확인해봐야 할 것 같습니다.
현재 Shared 디렉토리 내 `Title`, `Input`, `Select`, `Footer` 컴포넌트를 만들어 조립하는 방식으로 
세분화 해두었습니다. 


<br />

## 잠깐! 확인해보셨나요?

- [X]  셀프 리뷰는 완료하셨나요?
- [X]  가장 최신 브랜치를 pull했나요?
- [X]  base 브랜치명을 확인하셨나요? (Front, Backend, feature 등)
- [X]  코드 컨벤션을 모두 지켰나요?
- [X]  적절한 라벨이 있나요?
- [X]  assignee가 있나요?

<br />

## Attachment(선택사항) 

### 주소 입력 페이지 
구현된 주소 입력 페이지도 함께 참고 부탁드립니다.

![프로젝트 주소 입력 페이지](https://github.com/Figci/Figci-Client/assets/43771772/479c70a2-3bb3-465e-8cf1-69f089b5955f)

<br />
