### PR TITLE
Feat: 비교 페이지 - 페이지 재선택 & 피그마 열기 팝업

### DIFF
--- a/constants/timeConstants.js
+++ b/constants/timeConstants.js
@@ -1,5 +1,6 @@
 const DELAY_TIME = {
   TOAST: 3000,
+  OPEN_ON_FIGMA: 2000,
 };
 
 export default DELAY_TIME;

--- a/constants/timeConstants.js
+++ b/constants/timeConstants.js
@@ -1,6 +1,6 @@
 const DELAY_TIME = {
   TOAST: 3000,
-  OPEN_ON_FIGMA: 2000,
+  OPEN_ON_FIGMA: 1500,
 };
 
 export default DELAY_TIME;

--- a/src/components/DiffingResult/index.jsx
+++ b/src/components/DiffingResult/index.jsx
@@ -187,7 +187,7 @@ function DiffingResult() {
             <div className="profile">
               <div className="line" />
               <div className="profile-image"></div>
-              <p className="username">김픽시</p>
+              <p className="username"></p>
             </div>
           </div>
         </header>

--- a/src/components/DiffingResult/index.jsx
+++ b/src/components/DiffingResult/index.jsx
@@ -60,6 +60,8 @@ function DiffingResult() {
         pageId,
       );
 
+      console.log(diffingResult);
+
       if (diffingResult.result === "error") {
         setIsLoaded(false);
 

--- a/src/components/DiffingResult/index.jsx
+++ b/src/components/DiffingResult/index.jsx
@@ -29,7 +29,7 @@ function DiffingResult() {
   const navigate = useNavigate();
 
   const versionStatus = useProjectVersionStore(state => state.byDates);
-  const { status, clearPage, setStatus } = usePageStatusStore();
+  const { status, clearPageStatus, setStatus } = usePageStatusStore();
   const {
     projectKey,
     projectUrl,
@@ -106,7 +106,7 @@ function DiffingResult() {
   const handlePageSelect = ev => {
     const newSelectedPageId = ev.target.value;
 
-    clearPage();
+    clearPageStatus();
     setStatus({ pageId: newSelectedPageId });
     setClickedPageId(newSelectedPageId);
   };
@@ -325,7 +325,7 @@ const TextWrapper = styled.div`
   margin-bottom: 48px;
   width: 500px;
 
-  .reversion-title {
+  .re-version-title {
     margin-bottom: 28px;
 
     color: #000000;
@@ -336,7 +336,7 @@ const TextWrapper = styled.div`
     text-align: center;
   }
 
-  .reversion-content {
+  .re-version-content {
     display: block;
 
     color: #495057;

--- a/src/components/NewProject/index.jsx
+++ b/src/components/NewProject/index.jsx
@@ -59,6 +59,7 @@ function NewProject() {
     }
 
     const projectKey = getProjectKeyFromURI(inputValue);
+    const projectUrl = inputValue;
 
     setStatus({ projectKey, projectUrl: inputValue });
 
@@ -127,6 +128,7 @@ const ContentsWrapper = styled.div`
     padding: 0px 24px;
     border-radius: 8px;
     border: 2px solid #000000;
+    margin-top: 12px;
     margin-bottom: 12px;
 
     background-color: #ffffff;

--- a/src/components/ProjectPage/index.jsx
+++ b/src/components/ProjectPage/index.jsx
@@ -103,7 +103,9 @@ function ProjectPage() {
       )}
       <ProjectPageWrapper>
         <Title title={contents.title} />
-        <Select selectInfo={contents.selectInfo} />
+        <div className="select">
+          <Select selectInfo={contents.selectInfo} />
+        </div>
       </ProjectPageWrapper>
       <BottomNavigator buttons={contents.buttons} />
     </>
@@ -115,6 +117,11 @@ const ProjectPageWrapper = styled.div`
   width: 100%;
   height: 100%;
   padding: 64px;
+
+  .select {
+    width: 60%;
+    margin-top: 64px;
+  }
 `;
 
 export default ProjectPage;

--- a/src/components/ProjectVersion/index.jsx
+++ b/src/components/ProjectVersion/index.jsx
@@ -204,17 +204,20 @@ function ProjectVersion() {
 }
 
 const ContentsWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
   box-sizing: border-box;
   width: 100%;
   height: 100%;
   padding: 64px;
 `;
 
-const HorizontalAlign = styled.form`
-  display: flex;
-  justify-content: flex-start;
-  align-items: flex-end;
-  width: 100%;
+const HorizontalAlign = styled.div`
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  column-gap: 24px;
+  width: 70%;
+  margin-top: 64px;
 `;
 
 export default ProjectVersion;

--- a/src/components/Sidebar/index.jsx
+++ b/src/components/Sidebar/index.jsx
@@ -8,10 +8,12 @@ import Modal from "../shared/Modal";
 import Button from "../shared/Button";
 import Description from "../shared/Description";
 
+import usePageListStore from "../../../store/projectPage";
+import usePageStatusStore from "../../../store/projectInit";
 import updateFigmaUrl from "../../../utils/updateFigmaUrl";
 import DELAY_TIME from "../../../constants/timeConstants";
 
-function Sidebar({ framesInfo, projectUrl, onFrameSelect }) {
+function Sidebar({ framesInfo, projectUrl, onPageSelect, onFrameSelect }) {
   const [frameId, setFrameId] = useState(null);
   const [frameName, setFrameName] = useState(null);
   const [selectedPageId, setSelectedPageId] = useState(null);
@@ -20,6 +22,9 @@ function Sidebar({ framesInfo, projectUrl, onFrameSelect }) {
 
   const navigate = useNavigate();
 
+  const { status } = usePageStatusStore();
+  const { byPageIds } = usePageListStore();
+
   const handleFrameClick = ev => {
     ev.preventDefault();
 
@@ -27,10 +32,6 @@ function Sidebar({ framesInfo, projectUrl, onFrameSelect }) {
     setFrameName(ev.target.getAttribute("data-name"));
 
     onFrameSelect(frameId, frameName);
-  };
-
-  const handlePageSelect = ev => {
-    setSelectedPageId(ev.target.value);
   };
 
   const currentFigmaUrlOpen = () => {
@@ -50,7 +51,7 @@ function Sidebar({ framesInfo, projectUrl, onFrameSelect }) {
   };
 
   useEffect(() => {
-    if (framesInfo.length > 0 && frameId === null) {
+    if (framesInfo.length > 0 && Object.keys(byPageIds).length > 0) {
       const firstFrame = framesInfo[0];
 
       setFrameId(firstFrame.id);
@@ -115,11 +116,11 @@ function Sidebar({ framesInfo, projectUrl, onFrameSelect }) {
       {isClickedFigmaUrl && (
         <ModalWrapper>
           <Modal>
-            <h1 className="popup-title">
-              피그마에서 <br />
-              {frameName} 여는 중
-            </h1>
-            <span>현재 보고계신 화면이 있는 피그마 링크로 이동할게요.</span>
+            <h1 className="popup-title">피그마에서 {frameName} 여는 중</h1>
+            <span className="popup-description">
+              현재 보고계신 화면이 있는 피그마 링크로 이동할게요.
+              <br /> 피그마 파일은 새 창으로 열려요.
+            </span>
           </Modal>
         </ModalWrapper>
       )}
@@ -131,8 +132,16 @@ function Sidebar({ framesInfo, projectUrl, onFrameSelect }) {
               id="page"
               type="select"
               aria-label="select"
-              onChange={handlePageSelect}
-            />
+              onChange={onPageSelect}
+              value={status.pageId || ""}
+            >
+              {byPageIds &&
+                Object.keys(byPageIds).map(pageId => (
+                  <option key={pageId} value={pageId}>
+                    {byPageIds[pageId]}
+                  </option>
+                ))}
+            </select>
           </label>
         </div>
         <div className="frame-list">
@@ -181,11 +190,28 @@ const ModalWrapper = styled.div`
   align-items: center;
 
   .popup-title {
-    font-size: 1.8 rem;
+    width: 100%;
+    margin-bottom: 12px;
+
+    color: #000000;
+    font-size: 1.5rem;
     font-style: normal;
-    font-weight: 800;
+    font-weight: 700;
     text-align: center;
     line-height: 32px;
+  }
+
+  .popup-description {
+    width: 100%;
+    margin-right: 20px;
+    margin-left: 20px;
+
+    color: #495057;
+    font-size: 0.875rem;
+    font-style: normal;
+    font-weight: 500;
+    text-align: center;
+    line-height: 24px;
   }
 `;
 
@@ -195,6 +221,22 @@ const SidebarWrapper = styled.div`
   box-sizing: border-box;
   width: 305px;
   border-right: 2px solid #000000;
+
+  select {
+    width: 100%;
+    height: 64px;
+    padding: 0px 24px;
+    border-radius: 8px;
+    border: 2px solid #000000;
+    margin-top: 12px;
+    margin-bottom: 12px;
+
+    background-color: #ffffff;
+    font-size: 1rem;
+    font-style: normal;
+    font-weight: 500;
+    line-height: 28px;
+  }
 
   .page {
     padding: 24px;
@@ -240,7 +282,7 @@ const SidebarWrapper = styled.div`
 
   .title {
     color: #000000;
-    font-size: 1.25rem;
+    font-size: 1.125rem;
     font-style: normal;
     font-weight: 700;
     line-height: 28px;

--- a/src/components/Sidebar/index.jsx
+++ b/src/components/Sidebar/index.jsx
@@ -6,7 +6,6 @@ import { nanoid } from "nanoid";
 
 import Modal from "../shared/Modal";
 import Button from "../shared/Button";
-import Modal from "../shared/Modal";
 import Description from "../shared/Description";
 
 import updateFigmaUrl from "../../../utils/updateFigmaUrl";

--- a/src/components/Sidebar/index.jsx
+++ b/src/components/Sidebar/index.jsx
@@ -16,7 +16,6 @@ import DELAY_TIME from "../../../constants/timeConstants";
 function Sidebar({ framesInfo, projectUrl, onPageSelect, onFrameSelect }) {
   const [frameId, setFrameId] = useState(null);
   const [frameName, setFrameName] = useState(null);
-  const [selectedPageId, setSelectedPageId] = useState(null);
   const [isClickedNewProject, setIsClickedNewProject] = useState(false);
   const [isClickedFigmaUrl, setIsClickedFigmaUrl] = useState(false);
 
@@ -117,10 +116,11 @@ function Sidebar({ framesInfo, projectUrl, onPageSelect, onFrameSelect }) {
         <ModalWrapper>
           <Modal>
             <h1 className="popup-title">피그마에서 {frameName} 여는 중</h1>
-            <span className="popup-description">
-              현재 보고계신 화면이 있는 피그마 링크로 이동할게요.
-              <br /> 피그마 파일은 새 창으로 열려요.
-            </span>
+            <Description
+              className="re-version-description"
+              size="medium"
+              text="현재 보고계신 화면이 있는 피그마 링크로 이동할게요.\n피그마 파일은 새 창으로 열려요."
+            />
           </Modal>
         </ModalWrapper>
       )}

--- a/src/components/Sidebar/index.jsx
+++ b/src/components/Sidebar/index.jsx
@@ -14,10 +14,10 @@ import updateFigmaUrl from "../../../utils/updateFigmaUrl";
 import DELAY_TIME from "../../../constants/timeConstants";
 
 function Sidebar({ framesInfo, projectUrl, onPageSelect, onFrameSelect }) {
-  const [frameId, setFrameId] = useState(null);
-  const [frameName, setFrameName] = useState(null);
+  const [frameInformation, setFrameInformation] = useState({});
   const [isClickedNewProject, setIsClickedNewProject] = useState(false);
-  const [isClickedFigmaUrl, setIsClickedFigmaUrl] = useState(false);
+  const [isClickedOpenFigmaButton, setIsClickedOpenFigmaButton] =
+    useState(false);
 
   const navigate = useNavigate();
 
@@ -27,19 +27,21 @@ function Sidebar({ framesInfo, projectUrl, onPageSelect, onFrameSelect }) {
   const handleFrameClick = ev => {
     ev.preventDefault();
 
-    setFrameId(ev.target.getAttribute("data-id"));
-    setFrameName(ev.target.getAttribute("data-name"));
+    const frameId = ev.target.getAttribute("data-id");
+    const frameName = ev.target.getAttribute("data-name");
+
+    setFrameInformation({ frameId, frameName });
 
     onFrameSelect(frameId, frameName);
   };
 
   const currentFigmaUrlOpen = () => {
-    const figmaUrl = updateFigmaUrl(projectUrl, frameId);
+    const figmaUrl = updateFigmaUrl(projectUrl, frameInformation.frameId);
 
     return setTimeout(() => {
       window.open(figmaUrl, "_blank");
 
-      setIsClickedFigmaUrl(false);
+      setIsClickedOpenFigmaButton(false);
     }, DELAY_TIME.OPEN_ON_FIGMA);
   };
 
@@ -50,17 +52,19 @@ function Sidebar({ framesInfo, projectUrl, onPageSelect, onFrameSelect }) {
   };
 
   useEffect(() => {
-    if (framesInfo.length > 0 && Object.keys(byPageIds).length > 0) {
+    if (framesInfo.length > 0) {
       const firstFrame = framesInfo[0];
 
-      setFrameId(firstFrame.id);
-      setFrameName(firstFrame.name);
+      setFrameInformation({
+        frameId: firstFrame.id,
+        frameName: firstFrame.name,
+      });
     }
   }, [framesInfo]);
 
   useEffect(() => {
     const timerId = (() => {
-      if (isClickedFigmaUrl) {
+      if (isClickedOpenFigmaButton) {
         return currentFigmaUrlOpen();
       }
     })();
@@ -70,7 +74,7 @@ function Sidebar({ framesInfo, projectUrl, onPageSelect, onFrameSelect }) {
         clearTimeout(timerId);
       }
     };
-  }, [isClickedFigmaUrl]);
+  }, [isClickedOpenFigmaButton]);
 
   return (
     <>
@@ -112,17 +116,19 @@ function Sidebar({ framesInfo, projectUrl, onPageSelect, onFrameSelect }) {
           </ButtonWrapper>
         </Modal>
       )}
-      {isClickedFigmaUrl && (
-        <ModalWrapper>
-          <Modal>
-            <h1 className="popup-title">피그마에서 {frameName} 여는 중</h1>
+      {isClickedOpenFigmaButton && (
+        <Modal>
+          <TextWrapper>
+            <h1 className="figma-url-title">
+              피그마에서 {frameInformation.frameName} 여는 중
+            </h1>
             <Description
               className="re-version-description"
               size="medium"
               text="현재 보고계신 화면이 있는 피그마 링크로 이동할게요.\n피그마 파일은 새 창으로 열려요."
             />
-          </Modal>
-        </ModalWrapper>
+          </TextWrapper>
+        </Modal>
       )}
       <SidebarWrapper>
         <div className="page">
@@ -146,7 +152,7 @@ function Sidebar({ framesInfo, projectUrl, onPageSelect, onFrameSelect }) {
         </div>
         <div className="frame-list">
           <div className="titles">
-            <h3 className="title">전체 변경 화면 </h3>
+            <h3 className="title">전체 변경 화면</h3>
             <h3 className="title-number">{framesInfo.length}</h3>
           </div>
           <ul role="presentation" onClick={handleFrameClick}>
@@ -155,7 +161,7 @@ function Sidebar({ framesInfo, projectUrl, onPageSelect, onFrameSelect }) {
                 key={nanoid(10)}
                 data-id={frame.id}
                 data-name={frame.name}
-                className={`frame-name ${frameId === frame.id ? "active" : ""}`}
+                className={`frame-name ${frameInformation.frameId === frame.id ? "active" : ""}`}
               >
                 {frame.name}
               </li>
@@ -165,7 +171,7 @@ function Sidebar({ framesInfo, projectUrl, onPageSelect, onFrameSelect }) {
         <div className="buttons">
           <Button
             handleClick={() => {
-              setIsClickedFigmaUrl(true);
+              setIsClickedOpenFigmaButton(true);
             }}
             size="medium"
             usingCase="solid"
@@ -184,36 +190,6 @@ function Sidebar({ framesInfo, projectUrl, onPageSelect, onFrameSelect }) {
     </>
   );
 }
-
-const ModalWrapper = styled.div`
-  display: flex;
-  align-items: center;
-
-  .popup-title {
-    width: 100%;
-    margin-bottom: 12px;
-
-    color: #000000;
-    font-size: 1.5rem;
-    font-style: normal;
-    font-weight: 700;
-    text-align: center;
-    line-height: 32px;
-  }
-
-  .popup-description {
-    width: 100%;
-    margin-right: 20px;
-    margin-left: 20px;
-
-    color: #495057;
-    font-size: 0.875rem;
-    font-style: normal;
-    font-weight: 500;
-    text-align: center;
-    line-height: 24px;
-  }
-`;
 
 const SidebarWrapper = styled.div`
   display: flex;
@@ -334,6 +310,18 @@ const TextWrapper = styled.div`
     font-style: normal;
     text-align: center;
     line-height: 24px;
+  }
+
+  .figma-url-title {
+    width: 100%;
+    margin: 40px 0 12px;
+
+    color: #000000;
+    font-size: 1.5rem;
+    font-style: normal;
+    font-weight: 700;
+    text-align: center;
+    line-height: 32px;
   }
 `;
 

--- a/src/components/shared/BottomNavigator.jsx
+++ b/src/components/shared/BottomNavigator.jsx
@@ -34,6 +34,8 @@ const BottomNavWrapper = styled.div`
   padding: 24px 48px;
   border-top: 2px solid #000000;
 
+  background-color: #ffffff;
+
   button {
     margin-left: 16px;
   }

--- a/src/components/shared/Button.jsx
+++ b/src/components/shared/Button.jsx
@@ -2,11 +2,12 @@ import styled, { css } from "styled-components";
 
 const BUTTON_SIZES = {
   small: css`
-    --button-min-width: 100px;
+    --button-min-width: 64px;
     --button-min-height: 40px;
     --button-font-size: 0.875rem;
+    --button-font-weight: 700;
     --button-padding: 8px 20px;
-    --button-border: 2px solid #080404;
+    --button-border: 2px solid #000000;
     --button-radius: 24px;
   `,
   medium: css`
@@ -74,6 +75,7 @@ const StyledButton = styled.button`
   border-radius: var(--button-radius, 8px);
 
   font-size: var(--button-font-size, 1rem);
+  font-weight: var(--button-font-weight, 600);
   color: var(--button-color, #ffffff);
   background-color: var(--button-background-color, #2623fb);
   cursor: pointer;

--- a/src/components/shared/Modal.jsx
+++ b/src/components/shared/Modal.jsx
@@ -18,7 +18,7 @@ const ModalBackground = styled.div`
   width: 100%;
   height: 100%;
 
-  background-color: rgba(0, 0, 0, 0.4);
+  background-color: rgba(0, 0, 0, 0.75);
 `;
 
 const ModalContainer = styled.div`

--- a/src/components/shared/Select.jsx
+++ b/src/components/shared/Select.jsx
@@ -38,8 +38,7 @@ const SelectWrapper = styled.div`
     padding: 0px 24px;
     border-radius: 8px;
     border: 2px solid #000000;
-    margin-top: 12px;
-    margin-bottom: 12px;
+    margin: 12px 0;
 
     background-color: #ffffff;
     font-size: 1rem;

--- a/src/components/shared/Select.jsx
+++ b/src/components/shared/Select.jsx
@@ -30,16 +30,15 @@ function Select({ selectInfo }) {
 
 const SelectWrapper = styled.div`
   box-sizing: border-box;
-  padding-top: 48px;
-  margin-right: 24px;
+  flex-grow: 1;
 
   select {
-    display: flex;
-    width: 440px;
+    width: 100%;
     height: 64px;
     padding: 0px 24px;
     border-radius: 8px;
     border: 2px solid #000000;
+    margin-top: 12px;
     margin-bottom: 12px;
 
     background-color: #ffffff;
@@ -62,6 +61,7 @@ const SelectWrapper = styled.div`
 
   .description {
     display: block;
+    width: 500px;
 
     color: #868e96;
     font-size: 1rem;

--- a/src/components/shared/Select.jsx
+++ b/src/components/shared/Select.jsx
@@ -50,7 +50,6 @@ const SelectWrapper = styled.div`
 
   .label {
     display: block;
-    margin-bottom: 12px;
 
     color: #000000;
     font-size: 1rem;

--- a/store/projectInit.js
+++ b/store/projectInit.js
@@ -5,7 +5,6 @@ const initStore = set => {
     status: {
       projectUrl: null,
       projectKey: null,
-      projectUrl: null,
       beforeDate: null,
       beforeVersion: null,
       afterDate: null,

--- a/store/projectInit.js
+++ b/store/projectInit.js
@@ -5,6 +5,7 @@ const initStore = set => {
     status: {
       projectUrl: null,
       projectKey: null,
+      projectUrl: null,
       beforeDate: null,
       beforeVersion: null,
       afterDate: null,

--- a/utils/updateFigmaUrl.js
+++ b/utils/updateFigmaUrl.js
@@ -1,0 +1,10 @@
+const updateFigmaUrl = (url, NodeId) => {
+  const basePattern =
+    /(https:\/\/www\.figma\.com\/file\/[\w-]+\/[\w-%+]+\?type=design&node-id=)/;
+  const modifiedNodeId = NodeId.replace(":", "-");
+  const newUrl = `${basePattern.exec(url)[0]}${modifiedNodeId}&mode=design`;
+
+  return newUrl;
+};
+
+export default updateFigmaUrl;


### PR DESCRIPTION
## Fix (이슈 번호)
closes #10

<br />

## 해결하려던 문제를 알려주세요!
1. `Sidebar`에 있는 `Select`에서 `Page`를 선택할 때, 다른 `Page`를 선택할 시 서버에 새로 선택한 
`pageId`를 전달해 새로운 `result`를 받아 `FrameList`에 화면 목록과 캔버스에 결과 데이터를 전달해주려 했습니다.
2. 현재 캔버스에 띄어진 해당 화면을 볼 수 있도록 해당 `NodeId` 화면이 `Focus`된 피그마 사이트로 
이동할 수 있는 기능을 구현해 버튼에 연결하려 했습니다.

### 구현 중 문제 사항

`Zustand` 글로벌 상태를 하위 컴포넌트에서 업데이트하고, 업데이트된 상태를 하위 컴포넌트에서 
상위 컴포넌트에 전달해 전체적으로 리렌더링을 시키려 했는데 렌더링이 되지 않았습니다.

**→ (컴포넌트 분리 상황) 비교 결과 페이지는 상위 컴포넌트 `DiffingResult`, 
하위 컴포넌트 `Sidebar`로 관심사에 따라 역할과 레이아웃이 분리되어 있습니다.**

<br />

## 어떻게 해결했나요?
### 시도 방법 01

Sidebar 내부에 있는 Select를 누를 시, Sidebar 내부에 있는 이벤트 핸들러 함수에서 
Store에 있는 글로벌 상태를 업데이트하고, pageId가 달라지면, 상위 컴포넌트인 DiffingResult 컴포넌트 내에서 
상태가 달라지는 걸 구독하고 있기 때문에 UseEffect 내 의존성으로 pageId를 추가해 리렌더링 되도록 로직을 구성했습니다. 

**(1) DiffingResult 컴포넌트**

```jsx
function DiffingResult() {
const [selectedFrame, setSelectedFrame] = useState(null);
const {
    projectKey,
    projectUrl,
    beforeDate,
    beforeVersion,
    afterDate,
    afterVersion,
    pageId,
  } = usePageStatusStore(state => state.status);
}
const { byPageIds } = usePageListStore();

const handleFrameSelect = (frameId, frameName) => {
    setSelectedFrame({ id: frameId, name: frameName });
  };
}
```

**(2) `Diffing Result` 컴포넌트 내 변경사항 비교 로직**

```jsx
useEffect(() => {
    const fetchDiffingResult = async () => {
      setIsLoaded(true);

      const diffingResult = await getDiffingResult(
        projectKey,
        beforeVersion,
        afterVersion,
        pageId,
      );

      if (diffingResult.result === "error") {
        setIsLoaded(false);

        setToastMessage(diffingResult.message);
        setToast(true);

        navigate(-1);
      }

      const frames = diffingResult.content.frames.map(frame => {
        return {
          name: frame.name,
          id: frame.frameId,
        };
      });

      setFrameList(frames);

      setIsLoaded(false);
    };

    if (pageId) {
      fetchDiffingResult();
    }
  }, [pageId]);
```

**(3) `DiffingResult` 내 `Sidebar` 컴포넌트**

```jsx
<Sidebar
 pageId={pageId}
 pageName={byPageIds[pageId]}
 framesInfo={frameList}
 projectUrl={projectUrl}
 onFrameSelect={handleFrameSelect}
 setClickedPageId={setClickedPageId}
/>
```

(4) `**Sidebar` 컴포넌트 로직**

```jsx
function Sidebar({ framesInfo, projectUrl, onFrameSelect }) {
	const [clickedPageId, setClickedPageId] = useState("");
	const { status, clearPage, setStatus } = usePageStatusStore();

	const handleFrameClick = ev => {
    ev.preventDefault();

    setFrameId(ev.target.getAttribute("data-id"));
    setFrameName(ev.target.getAttribute("data-name"));

    onFrameSelect(frameId, frameName);
  };

	const handlePageSelect = ev => {
    const newSelectedPageId = ev.target.value;

    clearPage();
    setStatus({ pageId: newSelectedPageId });
    setClickedPageId(newSelectedPageId);
  };
...
}
```

https://github.com/Figci/Figci-Client/assets/43771772/133a5ca2-aa4c-4f7d-a3a8-fda23f94e76f

테스트 성공 유무 : `실패` , 해당 방법으로는 하위 컴포넌트인 Sidebar에 있는 Select는 상태가 반영되어 리렌더링되지만 부모 컴포넌트나 부모 컴포넌트의 상태를 prop으로 받고 있는 화면 리스트는 업데이트 되지 않고, 이벤트 발생이나 새로고침을 해야 글로벌 상태가 반영되었습니다.

**→ 글로벌 상태 업데이트 지연 + 상위 컴포넌트 리렌더링 및 로직 미반영 이슈**

<br />

### 시도 방법 02(테스트 성공)

**(1) DiffingResult 컴포넌트**

```jsx
function DiffingResult() {
const [clickedPageId, setClickedPageId] = useState(""); //부모 컴포넌트로 페이지 지역 상태 추가
const { status, clearPage, setStatus } = usePageStatusStore(); //
  const {
    projectKey,
    projectUrl,
    beforeDate,
    beforeVersion,
    afterDate,
    afterVersion,
    pageId,
  } = status; 

const handleFrameSelect = (frameId, frameName) => {
    setSelectedFrame({ id: frameId, name: frameName });
  };
}

const handlePageSelect = ev => {
    const newSelectedPageId = ev.target.value;

    clearPage();
    setStatus({ pageId: newSelectedPageId });
    setClickedPageId(newSelectedPageId);
  }; //해당 함수 추가
```

기존에 Sidebar에 있던 DiffingResult 내에 글로벌 상태를 변경시켜주기 위해 clearPage 메소드와 setStatus 메소드를 호출했습니다. (자식 컴포넌트에 있던 이벤트 핸들러를 상위 부모 컴포넌트에 선언해 prop으로 넘겨주는 방식)

**(2) `Diffing Result` 컴포넌트 내 변경사항 비교 로직**

```jsx
useEffect(() => {
    const fetchDiffingResult = async () => {
      setIsLoaded(true);

      const diffingResult = await getDiffingResult(
        projectKey,
        beforeVersion,
        afterVersion,
        pageId,
      );

      if (diffingResult.result === "error") {
        setIsLoaded(false);

        setToastMessage(diffingResult.message);
        setToast(true);

        navigate(-1);
      }

      const frames = diffingResult.content.frames.map(frame => {
        return {
          name: frame.name,
          id: frame.frameId,
        };
      });

      setFrameList(frames);
      setIsLoaded(false);
    };

    if (pageId) {
      fetchDiffingResult();
    }
  }, [clickedPageId]); //클릭되는 pageId를 의존성 배열에 추가
```

기존의 pageId가 아닌 clickedPageId로 이벤트가 발생하는 PageId를 의존성 배열에 넣어 사용자가 다른 페이지를 선택할 시 Diffing 로직을 실행할 수 있도록 변경했습니다.

**(3) `DiffingResult` 내 `Sidebar` 컴포넌트**

```jsx
<Sidebar
  framesInfo={frameList}
  projectUrl={projectUrl}
  onPageSelect={handlePageSelect} 
  onFrameSelect={handleFrameSelect}
  setClickedPageId={setClickedPageId} // 부모 컴포넌트의 setState 함수 전달
          />
```

부모 컴포넌트인 DiffingResult setState 함수를 전달하고, Sidebar 내에서 이벤트가 발생할 때마다 
부모 컴포넌트까지 상태를 끌어올려두었습니다.

해당 방식으로 `Sidebar`에서 이벤트 발생 시, 부모 컴포넌트인 `DiffingResult` 컴포넌트 내에서 이벤트(상태)를 끌어와 
글로벌 상태로 저장하고, 전체 컴포넌트를 리렌더링 시켜 사용자가 페이지를 선택할 때 선택한 페이지의 화면리스트, 
`Diffing`한 데이터를 가져올 수 있도록 로직을 수정해두었습니다.

https://github.com/Figci/Figci-Client/assets/43771772/f1959404-9b29-48df-bf1b-9d8a7b44360a

→ 글로벌 상태로 `pageId`를 저장할 때, 이미 클릭 이벤트가 발생하고 렌더링이 된 시점이라 페이지를 새로 고침하거나 
렌더링이 되는 시점 이후로 이벤트가 한번 더 발생해야지만 상태가 업데이트되어 상위/하위 컴포넌트에 반영되는 것 같습니다.  
글로벌 상태가 반영되고 상위 컴포넌트까지 리렌더링이 되지 않아 발생한 문제라 해당 방식으로 해결했습니다!


추후 리팩토링 시, 아래 글이나 여러 방법들을 참고해 더 나은 방법이 있을지 고민해보겠습니다.

[Zustand 업데이트 지연 시 해결방법](https://velog.io/@dpldpl/%EC%A0%84%EC%97%AD-%EC%83%81%ED%83%9C-%EA%B4%80%EB%A6%AC-Zustand-%EB%A1%9C%EA%B7%B8%EC%9D%B8-%ED%9B%84-%EC%82%AC%EC%9A%A9%EC%9E%90-%EC%A0%95%EB%B3%B4-%EC%9C%A0%EC%A7%80%ED%95%98%EA%B8%B0-%EB%AC%B8%EC%A0%9C-%ED%95%B4%EA%B2%B0)

<br />

## 우려사항이 있나요?(선택사항)

### 다시 만난 ESLint Error(웹 접근성)
현재 만난 에러는 웹접근성이 고려되지 않아 발생한 에러였습니다. 
`label` 내에 위치한 `select`이지만, `label `안에 사용해도 동일한 에러가 계속떠서 문제의 원인을 찾아보니
해당 원인은 사용자가 스크린 리더와 같은 보조 기술을 사용할 때 어떤 태그인지 이해하고 조작할 수 있도록 해주는 속성이기 때문에
동일한 에러가 뜨신다면 `aria-label` 설정 부탁드립니다. 아래 글도 참고로 읽어주세요 🙏

<img width="547" alt="스크린샷 2024-02-12 오전 3 40 46" src="https://github.com/Figci/Figci-Client/assets/43771772/08e9fcf8-fd42-42cf-9710-d5d83cb0c979">
<img width="461" alt="스크린샷 2024-02-12 오전 4 06 22" src="https://github.com/Figci/Figci-Client/assets/43771772/382c8aba-511b-4438-b721-3572c365fe6a">

[aria-label(mdn)](https://developer.mozilla.org/ko/docs/Web/Accessibility/ARIA/Attributes/aria-label)
<br />

## 잠깐! 확인해보셨나요?

- [X]  셀프 리뷰는 완료하셨나요?
- [X]  가장 최신 브랜치를 pull했나요?
- [X]  base 브랜치명을 확인하셨나요? (Front, Backend, feature 등)
- [X]  코드 컨벤션을 모두 지켰나요?
- [X]  적절한 라벨이 있나요?
- [X]  assignee가 있나요?

<br />

## Attachment(선택사항) 

### 피그마 외부 이동 팝업
<img width="803" alt="스크린샷 2024-02-12 오후 4 17 28" src="https://github.com/Figci/Figci-Client/assets/43771772/9e1e6ad0-5ac5-4b32-a531-89b209203e7b">


<br />
