### PR TITLE
🚑️ [Fix] 그룹 렌더링시 버튼 인스턴스 렌더 되지 않는 버그

### DIFF
--- a/services/createFabricObjects.js
+++ b/services/createFabricObjects.js
@@ -186,7 +186,7 @@ const renderText = (node, offsetCoordinates) => {
     left: style.absoluteBoundingBox.x + offsetCoordinates.dx,
     top: style.absoluteBoundingBox.y + offsetCoordinates.dy,
     width: style.absoluteBoundingBox.width,
-    // height: style.style.lineHeightPx,
+    height: style.style.lineHeightPx,
     fontSize: style.style.fontSize,
     fontFamily: style.style.fontFamily,
     fontWeight: style.style.fontWeight,

--- a/services/createFabricObjects.js
+++ b/services/createFabricObjects.js
@@ -35,6 +35,7 @@ const renderImage = async (nodeJSON, offsetCoordinates) => {
           rx: width / 2,
           ry: height / 2,
           absolutePositioned: true,
+          selectable: false,
         });
 
         fabric.Image.fromURL(nodeJSON.property.imageURL, fabricImage => {
@@ -69,12 +70,14 @@ const renderImage = async (nodeJSON, offsetCoordinates) => {
           rx: nodeJSON.property?.cornerRadius,
           ry: nodeJSON.property?.cornerRadius,
           absolutePositioned: true,
+          selectable: false,
         });
 
         fabric.Image.fromURL(nodeJSON.property.imageURL, fabricImage => {
           fabricImage.set({
             left: x + offsetCoordinates.dx,
             top: y + offsetCoordinates.dy,
+            selectable: false,
           });
 
           fabricImage.scaleToWidth(width);
@@ -118,6 +121,7 @@ const renderRect = async (node, offsetCoordinates) => {
     ry: style.cornerRadius || 0,
     visible: true,
     evented: true,
+    selectable: false,
   });
 };
 
@@ -140,6 +144,7 @@ const renderFrame = async (node, offsetCoordinates) => {
     ry: style.cornerRadius || 0,
     visible: true,
     evented: true,
+    selectable: false,
   });
 
   return frameObject;
@@ -166,8 +171,9 @@ const renderEllipse = async (node, offsetCoordinates) => {
     fill: backgroundColor && convertColorString(backgroundColor),
     stroke: strokes.length ? convertColorString(strokes[0].color) : 0,
     strokeAlign: style.strokeAlign && style.strokeAlign,
-    angle: style.property?.arcData?.endingAngle,
+    angle: style.arcData?.endingAngle,
     visible: true,
+    selectable: false,
   });
 };
 
@@ -176,11 +182,11 @@ const renderText = (node, offsetCoordinates) => {
   const backgroundColor = style.fills[0]?.color;
   const { strokes } = style;
 
-  return new fabric.Textbox(style.characters, {
+  const fabricTextObject = new fabric.Textbox(style.characters, {
     left: style.absoluteBoundingBox.x + offsetCoordinates.dx,
     top: style.absoluteBoundingBox.y + offsetCoordinates.dy,
     width: style.absoluteBoundingBox.width,
-    height: style.style.lineHeightPx,
+    // height: style.style.lineHeightPx,
     fontSize: style.style.fontSize,
     fontFamily: style.style.fontFamily,
     fontWeight: style.style.fontWeight,
@@ -193,7 +199,10 @@ const renderText = (node, offsetCoordinates) => {
     strokeLineCap: style.strokeLineCap && style.strokeLineCap,
     strokeLineJoin: style.strokeJoin && style.strokeJoin,
     verticalAlign: style.style.textAlignVertical.toLowerCase(),
+    selectable: false,
   });
+
+  return fabricTextObject;
 };
 
 const renderTriangle = (node, offsetCoordinates) => {
@@ -207,6 +216,7 @@ const renderTriangle = (node, offsetCoordinates) => {
     height: style.rotation > 0 ? position.height : -position.height,
     fill: convertColorString(style.fills[0].color),
     strokeWidth: style.strokeWeight,
+    selectable: false,
   });
 };
 
@@ -225,6 +235,7 @@ const renderDifference = (node, offsetCoordinates) => {
     ry: 5,
     evented: true,
     hasBorders: true,
+    selectable: false,
   });
 
   const diffContent = new fabric.Textbox(
@@ -244,6 +255,7 @@ const renderDifference = (node, offsetCoordinates) => {
       hasBorders: true,
       borderColor: "rgba(0, 0, 0, 1)",
       visible: false,
+      selectable: false,
     },
   );
 
@@ -265,6 +277,7 @@ const renderNewFrame = (node, offsetCoordinates) => {
     rx: 5,
     ry: 5,
     hasBorders: true,
+    selectable: false,
   });
 
   const diffContent = new fabric.Textbox(
@@ -287,6 +300,7 @@ const renderNewFrame = (node, offsetCoordinates) => {
       isWrapping: true,
       hasBorders: true,
       visible: false,
+      selectable: false,
     },
   );
 
@@ -307,6 +321,7 @@ const renderNewFrameInfo = (node, offsetCoordinates) => {
     strokeOpacity: 1,
     rx: 5,
     ry: 5,
+    selectable: false,
   });
 
   const diffContent = new fabric.Textbox("새로 생성된 프레임 입니다.", {
@@ -327,6 +342,7 @@ const renderNewFrameInfo = (node, offsetCoordinates) => {
     isWrapping: false,
     hasBorders: true,
     visible: false,
+    selectable: false,
   });
 
   return [diffRect, diffContent];

--- a/services/createFabricObjects.js
+++ b/services/createFabricObjects.js
@@ -362,6 +362,7 @@ const renderFunctionByFigmaType = {
   RECTANGLE: renderRect,
   TEXT: renderText,
   VECTOR: renderRect,
+  LINE: renderRect,
 };
 
 const createFabric = async (figmaNode, offsetCoordinates) => {

--- a/services/renderFabricFrame.js
+++ b/services/renderFabricFrame.js
@@ -87,9 +87,10 @@ const renderFabricFrame = async function (frameJSON, imageUrl) {
   }
 
   const fabricObjectArray = [...fabricObject.values()];
-  const objectGroup = new fabric.Group(fabricObjectArray);
 
-  this.add(objectGroup);
+  fabricObjectArray.forEach(fabricObject => {
+    this.add(fabricObject);
+  });
 };
 
 export default renderFabricFrame;

--- a/src/components/DiffingResult/index.jsx
+++ b/src/components/DiffingResult/index.jsx
@@ -214,6 +214,7 @@ function DiffingResult() {
       }
 
       renderFabricOnCanvas(diffingResult.content);
+
       canvasRef.current.renderAll();
     }
   }, [frameId]);


### PR DESCRIPTION
## Fix (이슈 번호)
 - Hotfix - 버튼이 렌더되지 않는 버그 수정

<br />

## 해결하려던 문제를 알려주세요!
1. 버튼 인스턴스 내부 객체가 렌더 되지 않는 문제

<br />

## 어떻게 해결했나요?
1. 객체를 그룹으로 설정할때 객체의 순서를 보장하지 않고 내부적으로 정렬하는 로직이 있다고 추정했습니다. 
 객체의 절대 위치나 순서를 전혀 조작하지 않고 그룹화만 할 수 있는 속성을 찾아보려고 했지만 찾지 못했습니다.

2. 객체를 그룹으로 묶어서 그룹을 렌더링 하지않고 객체별로 따로 렌더링 하였습니다.

3. 객체를 선택해서 조작할 수 없도록 모든 fabric 객체에 slectable 속성을 false로 설정했습니다.

<br />

## 우려사항이 있나요?(선택사항)
1.  LINE 타입은 렌더 함수가 존재하지 않아 LINE 타입이 포함된 프레임은 렌더 되지 않습니다.

<br />

## 잠깐! 확인해보셨나요?

- [x]  셀프 리뷰는 완료하셨나요?
- [x]  가장 최신 브랜치를 pull했나요?
- [x]  base 브랜치명을 확인하셨나요? (Front, Backend, feature 등)
- [x]  코드 컨벤션을 모두 지켰나요?
- [x]  적절한 라벨이 있나요?
- [x]  assignee가 있나요?