### PR TITLE
Test: 테스트 코드 작성(NewProject, ProjectPage)

### DIFF
--- a/src/spec/NewProject/NewProject.spec.jsx
+++ b/src/spec/NewProject/NewProject.spec.jsx
@@ -22,9 +22,9 @@ describe("NewProject Component Test", () => {
 
   it("모달 창 내 '좋아요!' 버튼을 누르면 모달이 닫혀야 합니다", () => {
     const modalElement = screen.getByText("Figci를 바로 사용할 수 있어요!");
-    const closeModalButton = screen.getByText("좋아요!");
+    const closeModalButtonElement = screen.getByText("좋아요!");
 
-    fireEvent.click(closeModalButton);
+    fireEvent.click(closeModalButtonElement);
 
     expect(modalElement).not.toBeInTheDocument();
   });

--- a/src/spec/NewProject/NewProject.spec.jsx
+++ b/src/spec/NewProject/NewProject.spec.jsx
@@ -1,6 +1,7 @@
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { BrowserRouter } from "react-router-dom";
 
+import Header from "../../components/Header/Header";
 import NewProject from "../../components/NewProject";
 
 const formatTargetComponent = targetComponent => {
@@ -9,21 +10,73 @@ const formatTargetComponent = targetComponent => {
 
 describe("NewProject Component Test", () => {
   beforeEach(() => {
+    render(formatTargetComponent(<Header />));
     render(formatTargetComponent(<NewProject />));
   });
 
   it("모달 창이 초기에 렌더링 되어야 합니다", () => {
-    const modalElement = screen.getByText(/Figci를 바로 사용할 수 있어요!/);
+    const modalElement = screen.getByText("Figci를 바로 사용할 수 있어요!");
 
     expect(modalElement.toBeInTheDocument);
   });
 
   it("모달 창 내 '좋아요!' 버튼을 누르면 모달이 닫혀야 합니다", () => {
-    const modalElement = screen.getByText(/Figci를 바로 사용할 수 있어요!/);
-    const closeModalButton = screen.getByText(/좋아요!/);
+    const modalElement = screen.getByText("Figci를 바로 사용할 수 있어요!");
+    const closeModalButton = screen.getByText("좋아요!");
 
     fireEvent.click(closeModalButton);
 
     expect(modalElement).not.toBeInTheDocument();
+  });
+
+  it("URL 입력 페이지 헤더에 서비스 로고와 캐치프라이즈가 렌더 되어야 합니다.", () => {
+    const logo = screen.getByAltText("figci-logo-img");
+    const catchphrase = screen.getByText(
+      /피그마 버전을 비교해*디자인 변경사항을 한눈에!/,
+    );
+
+    expect(logo).toBeInTheDocument();
+    expect(catchphrase).toBeInTheDocument();
+  });
+
+  it("URL 입력 페이지에서 타이틀과 입력 필드가 렌더 되어야 합니다", () => {
+    const title = screen.getByText(
+      "디자인 변경사항을 확인할 피그마 프로젝트 URL을 입력해주세요.",
+    );
+    const inputElement = screen.getByPlaceholderText(/url 주소를 입력해주세요/);
+
+    expect(title).toBeInTheDocument();
+    expect(inputElement).toBeInTheDocument();
+  });
+
+  it("URL 입력 페이지에서 다음 버튼이 렌더 되어야 합니다", () => {
+    const nextButtonElement = screen.getByText("다음");
+
+    expect(nextButtonElement).toBeInTheDocument();
+  });
+
+  it("유효하지 않은 URL일 경우 토스트 팝업 내 에러 메시지가 띄어져야 합니다", async () => {
+    const closeModalButton = screen.getByText("좋아요!");
+
+    fireEvent.click(closeModalButton);
+
+    const invalidUrl = "https://www.figma.com/1234";
+    const inputElement = screen.getByPlaceholderText(
+      "url 주소를 입력해주세요. (예: www.figma.com/abc)",
+    );
+
+    fireEvent.change(inputElement, { target: { value: invalidUrl } });
+
+    const submitButton = screen.getByText("다음");
+
+    fireEvent.click(submitButton);
+
+    waitFor(() => {
+      expect(
+        screen.queryByText(
+          "피그마 파일 URL 주소가 아니에요. 다시 입력해주세요🥲",
+        ),
+      ).toBeInTheDocument();
+    });
   });
 });

--- a/src/spec/NewProject/NewProject.spec.jsx
+++ b/src/spec/NewProject/NewProject.spec.jsx
@@ -1,0 +1,29 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { BrowserRouter } from "react-router-dom";
+
+import NewProject from "../../components/NewProject";
+
+const formatTargetComponent = targetComponent => {
+  return <BrowserRouter>{targetComponent}</BrowserRouter>;
+};
+
+describe("NewProject Component Test", () => {
+  beforeEach(() => {
+    render(formatTargetComponent(<NewProject />));
+  });
+
+  it("모달 창이 초기에 렌더링 되어야 합니다", () => {
+    const modalElement = screen.getByText(/Figci를 바로 사용할 수 있어요!/);
+
+    expect(modalElement.toBeInTheDocument);
+  });
+
+  it("모달 창 내 '좋아요!' 버튼을 누르면 모달이 닫혀야 합니다", () => {
+    const modalElement = screen.getByText(/Figci를 바로 사용할 수 있어요!/);
+    const closeModalButton = screen.getByText(/좋아요!/);
+
+    fireEvent.click(closeModalButton);
+
+    expect(modalElement).not.toBeInTheDocument();
+  });
+});

--- a/src/spec/NewProject/NewProject.spec.jsx
+++ b/src/spec/NewProject/NewProject.spec.jsx
@@ -1,4 +1,12 @@
-import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import {
+  render,
+  screen,
+  fireEvent,
+  waitFor,
+  cleanup,
+} from "@testing-library/react";
+import { afterEach } from "vitest";
+
 import { BrowserRouter } from "react-router-dom";
 
 import Header from "../../components/Header/Header";
@@ -14,6 +22,9 @@ describe("NewProject Component Test", () => {
     render(formatTargetComponent(<NewProject />));
   });
 
+  afterEach(() => {
+    cleanup();
+  });
   it("모달 창이 초기에 렌더링 되어야 합니다", () => {
     const modalElement = screen.getByText("Figci를 바로 사용할 수 있어요!");
 

--- a/src/spec/NewProject/NewProject.spec.jsx
+++ b/src/spec/NewProject/NewProject.spec.jsx
@@ -30,13 +30,13 @@ describe("NewProject Component Test", () => {
   });
 
   it("URL 입력 페이지 헤더에 서비스 로고와 캐치프라이즈가 렌더 되어야 합니다.", () => {
-    const logo = screen.getByAltText("figci-logo-img");
-    const catchphrase = screen.getByText(
+    const logoElement = screen.getByAltText("figci-logo-img");
+    const catchphraseElement = screen.getByText(
       /피그마 버전을 비교해*디자인 변경사항을 한눈에!/,
     );
 
-    expect(logo).toBeInTheDocument();
-    expect(catchphrase).toBeInTheDocument();
+    expect(logoElement).toBeInTheDocument();
+    expect(catchphraseElement).toBeInTheDocument();
   });
 
   it("URL 입력 페이지에서 타이틀과 입력 필드가 렌더 되어야 합니다", () => {
@@ -56,9 +56,9 @@ describe("NewProject Component Test", () => {
   });
 
   it("유효하지 않은 URL일 경우 토스트 팝업 내 에러 메시지가 띄어져야 합니다", async () => {
-    const closeModalButton = screen.getByText("좋아요!");
+    const closeModalButtonElement = screen.getByText("좋아요!");
 
-    fireEvent.click(closeModalButton);
+    fireEvent.click(closeModalButtonElement);
 
     const invalidUrl = "https://www.figma.com/1234";
     const inputElement = screen.getByPlaceholderText(
@@ -67,9 +67,9 @@ describe("NewProject Component Test", () => {
 
     fireEvent.change(inputElement, { target: { value: invalidUrl } });
 
-    const submitButton = screen.getByText("다음");
+    const submitButtonElement = screen.getByText("다음");
 
-    fireEvent.click(submitButton);
+    fireEvent.click(submitButtonElement);
 
     await waitFor(() => {
       expect(

--- a/src/spec/NewProject/NewProject.spec.jsx
+++ b/src/spec/NewProject/NewProject.spec.jsx
@@ -40,12 +40,12 @@ describe("NewProject Component Test", () => {
   });
 
   it("URL 입력 페이지에서 타이틀과 입력 필드가 렌더 되어야 합니다", () => {
-    const title = screen.getByText(
+    const titleElement = screen.getByText(
       "디자인 변경사항을 확인할 피그마 프로젝트 URL을 입력해주세요.",
     );
     const inputElement = screen.getByPlaceholderText(/url 주소를 입력해주세요/);
 
-    expect(title).toBeInTheDocument();
+    expect(titleElement).toBeInTheDocument();
     expect(inputElement).toBeInTheDocument();
   });
 
@@ -71,7 +71,7 @@ describe("NewProject Component Test", () => {
 
     fireEvent.click(submitButton);
 
-    waitFor(() => {
+    await waitFor(() => {
       expect(
         screen.queryByText(
           "피그마 파일 URL 주소가 아니에요. 다시 입력해주세요🥲",

--- a/src/spec/ProjectPage/ProjectPage.spec.jsx
+++ b/src/spec/ProjectPage/ProjectPage.spec.jsx
@@ -1,7 +1,7 @@
 import { render, screen, fireEvent, cleanup } from "@testing-library/react";
-import { QueryClient, QueryClientProvider } from "react-query";
 import { afterEach, expect } from "vitest";
 import { BrowserRouter } from "react-router-dom";
+import { QueryClient, QueryClientProvider } from "react-query";
 
 import ProjectPage from "../../components/ProjectPage";
 

--- a/src/spec/ProjectPage/ProjectPage.spec.jsx
+++ b/src/spec/ProjectPage/ProjectPage.spec.jsx
@@ -1,0 +1,45 @@
+import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { afterEach, expect } from "vitest";
+import { BrowserRouter } from "react-router-dom";
+
+import ProjectPage from "../../components/ProjectPage";
+
+import useProjectPageStore from "../../store/projectPage";
+
+const allPages = [
+  {
+    pageId: "1:2",
+    pageName: "morkup flow",
+  },
+  {
+    pageId: "333:1118",
+    pageName: "flow chart",
+  },
+  {
+    pageId: "223:398",
+    pageName: "design",
+  },
+];
+
+const queryClient = new QueryClient();
+
+const formatTargetComponent = targetComponent => {
+  return (
+    <QueryClientProvider client={queryClient}>
+      <BrowserRouter>{targetComponent}</BrowserRouter>
+    </QueryClientProvider>
+  );
+};
+
+beforeEach(() => {
+  const { setPages } = useProjectPageStore.getState();
+
+  setPages(allPages);
+
+  render(formatTargetComponent(<ProjectPage pages={allPages} />));
+});
+
+afterEach(() => {
+  cleanup();
+});

--- a/src/spec/ProjectPage/ProjectPage.spec.jsx
+++ b/src/spec/ProjectPage/ProjectPage.spec.jsx
@@ -50,10 +50,10 @@ describe("ProjectPage Component Test", () => {
 
     fireEvent.click(selectBoxElement);
 
-    const optionsElements = screen.getAllByRole("option");
+    const optionsElement = screen.getAllByRole("option");
 
-    expect(optionsElements[0].textContent).toBe(allPages[0].pageName);
-    expect(optionsElements[1].textContent).toBe(allPages[1].pageName);
+    expect(optionsElement[0].textContent).toBe(allPages[0].pageName);
+    expect(optionsElement[1].textContent).toBe(allPages[1].pageName);
   });
 
   it("비교 페이지 선택 페이지에서 타이틀과 셀렉트가 렌더 되어야 합니다", () => {

--- a/src/spec/ProjectPage/ProjectPage.spec.jsx
+++ b/src/spec/ProjectPage/ProjectPage.spec.jsx
@@ -43,3 +43,32 @@ beforeEach(() => {
 afterEach(() => {
   cleanup();
 });
+
+describe("ProjectPage Component Test", () => {
+  it("글로벌 상태에 저장된 프로젝트의 공통된 페이지들을 가져와서 렌더링 해야 합니다", () => {
+    const selectBoxElement = screen.getByRole("combobox");
+
+    fireEvent.click(selectBoxElement);
+
+    const optionsElements = screen.getAllByRole("option");
+
+    expect(optionsElements[0].textContent).toBe(allPages[0].pageName);
+    expect(optionsElements[1].textContent).toBe(allPages[1].pageName);
+  });
+
+  it("비교 페이지 선택 페이지에서 타이틀과 셀렉트가 렌더 되어야 합니다", () => {
+    const titleElement = screen.getByText("비교할 페이지를 선택해주세요.");
+    const selectBoxElement = screen.getByRole("combobox");
+
+    expect(titleElement).toBeInTheDocument();
+    expect(selectBoxElement).toBeInTheDocument();
+  });
+
+  it("비교 페이지 선택 페이지에서 이전, 비교하기 버튼이 렌더 되어야 합니다", () => {
+    const backButtonElement = screen.getByText("이전");
+    const compareButtonElement = screen.getByText("비교하기");
+
+    expect(backButtonElement).toBeInTheDocument();
+    expect(compareButtonElement).toBeInTheDocument();
+  });
+});

--- a/src/spec/ProjectPage/ProjectPage.spec.jsx
+++ b/src/spec/ProjectPage/ProjectPage.spec.jsx
@@ -1,5 +1,6 @@
 import { render, screen, fireEvent, cleanup } from "@testing-library/react";
-import { afterEach, expect } from "vitest";
+import { expect, afterEach } from "vitest";
+
 import { BrowserRouter } from "react-router-dom";
 import { QueryClient, QueryClientProvider } from "react-query";
 


### PR DESCRIPTION
## Fix (이슈 번호)
none

<br />

## 해결하려던 문제를 알려주세요!
`NewProject`, `ProjectPage` 컴포넌트 단위 테스트를 진행해야 했습니다.

<br />

## 어떻게 해결했나요?

### ProjectPage 내 zustand 관련 로직 추가
글로벌 상태에 저장된 프로젝트의 공통된 페이지를 가져와서 렌더링하는 테스트를 해야했고,
성호님이 참고용으로 주신 아래 링크와 성호님의 보일러 플레이트를 참고해 작업했습니다.

<br />

1. `MorkData` 및 `import`문으로 `useProjectPageStore` 추가
```javascript
import useProjectPageStore from "../../store/projectPage";

const allPages = [
  {
    pageId: "1:2",
    pageName: "morkup flow",
  },
  {
    pageId: "333:1118",
    pageName: "flow chart",
  },
  {
    pageId: "223:398",
    pageName: "design",
  },
];
``` 

### ProjectPage 내 React-Query Error

**만났던 에러**
> Error: No QueryClient set, use QueryClientProvider to set one
> useQueryClient node_modules/react-query/lib/react/QueryClientProvider.js:36:11
> useBaseQuery node_modules/react-query/lib/react/useBaseQuery.js:24:61
> Proxy.useQuery node_modules/react-query/lib/react/useQuery.js:14:41
> Module.getDiffingResultQuery [as default] src/services/getDiffingResultQuery.js:43:10

`react-query `라이브러리를 사용하는 컴포넌트를 테스트할 때 발생합니다. 
`react-query`의` useQuery `훅이나 관련 훅을 사용하는 컴포넌트를 렌더링할 때 
`QueryClientProvider`에 의해 제공되는 `QueryClient`가 설정되지 않았다는 것을 나타내는 것이었습니다.

`react-query`를 사용하는 컴포넌트를 테스트할 때는, 해당 컴포넌트를 `QueryClientProvider`로 감싸고 
적절한 `QueryClient `인스턴스를 제공해야 했는데 그 이유는 `react-query`가 내부적으로 사용하는 클라이언트 캐시와 설정을 초기화하는 데 필요해 아래 코드를 작성했습니다.

```javascript
import { QueryClient, QueryClientProvider } from "react-query";  //리액트 쿼리 import

const queryClient = new QueryClient();

const formatTargetComponent = targetComponent => {
  return (
    <QueryClientProvider client={queryClient}>
      <BrowserRouter>{targetComponent}</BrowserRouter>
    </QueryClientProvider>
  );
};

beforeEach(() => {
  const { setPages } = useProjectPageStore.getState();

  setPages(allPages);

  render(formatTargetComponent(<ProjectPage pages={allPages} />));
});
``` 


<br />

## 우려사항이 있나요?(선택사항)

### 추후 테스트 추가사항
`enter key`에 대한 로직을 테스트했는데, 일정 내 해당 키보드 이벤트 테스트 코드는 
조금 더 공부 + 보완 후 추가되어야 할 것 같아 테스트 코드 2차 작성 때 보완하려 합니다!

```javascript
it("키보드 엔터키를 눌러 폼을 제출할 수 있어야 합니다", () => {
  const validUrl = "https://www.figma.com/file/wQ5CcLlM53WqoqcJhMgcfj/240123-Userflow-%2B-feature-detail?type=design&node-id=223-398&mode=design&t=nsOsAMDPreQTn1gp-11";
 const inputElement = screen.getByPlaceholderText(/url 주소를 입력해주세요/);
    const formElement = screen.getByTagName("form");

    fireEvent.change(inputElement, { target: { value: validUrl } });
    fireEvent.keyDown(formElement, { key: "Enter", code: "Enter" });

    expect(navigateMock).toHaveBeenCalled();
  });
``` 

+ 혹시 해당 로직이 틀린 이유를 아시면, 의견 주시면 감사하겠습니다!

<br />

## 잠깐! 확인해보셨나요?

- [X]  셀프 리뷰는 완료하셨나요?
- [X]  가장 최신 브랜치를 pull했나요?
- [X]  base 브랜치명을 확인하셨나요? (Front, Backend, feature 등)
- [X]  코드 컨벤션을 모두 지켰나요?
- [X]  적절한 라벨이 있나요?
- [X]  assignee가 있나요?

<br />

## Attachment(선택사항) 
### ProjectPage 테스트 결과
![스크린샷 2024-02-26 오후 11 20 37](https://github.com/Figci/Figci-Client/assets/43771772/446f49f8-0fc1-414e-a1be-cfb9c9c959e9)

### NewProject 테스트 결과
![스크린샷 2024-02-26 오후 8 44 54](https://github.com/Figci/Figci-Client/assets/43771772/7277fb33-5d78-42a0-956e-1d0c54145834)


<br />
