### PR TITLE
Fix: 피그마 API 이미지 URL fetch 버그 수정

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,5 @@
+[[redirects]]
+  from = "/proxy/*"
+  to = "https://api.figma.com/:splat"
+  status = 200
+  force = true

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,4 +3,3 @@
   to = "https://api.figma.com/:splat"
   status = 200
   force = true
-  

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,3 +3,4 @@
   to = "https://api.figma.com/:splat"
   status = 200
   force = true
+  

--- a/src/utils/fetchImage.js
+++ b/src/utils/fetchImage.js
@@ -1,5 +1,7 @@
 const fetchImageUrl = async (projectKey, setToast) => {
-  const baseFigmaURL = `https://api.figma.com/v1/files/${projectKey}/images`;
+  const PROXY = window.location.hostname === 'localhost' ? '' : '/proxy';
+  
+  const baseFigmaURL = `${PROXY}/v1/files/${projectKey}/images`;
   
   const token = JSON.parse(localStorage.getItem("FigmaToken")).access_token;
 

--- a/src/utils/fetchImage.js
+++ b/src/utils/fetchImage.js
@@ -7,14 +7,12 @@ const fetchImageUrl = async (projectKey, setToast) => {
 
   try {
     if (!token) {
-      setToast({ status: true, message: "Figma 토큰이 유효하지 않습니다." });
+      setToast({ status: true, message: "The Figma token is invalid." });
 
       return;
     }
 
     const fetchFrameImageURLs = async () => {
-      console.log("baseFigmaURL & token", baseFigmaURL, token);
-
       const fetchData = await fetch(baseFigmaURL, {
         method: "GET",
         headers: {
@@ -22,10 +20,8 @@ const fetchImageUrl = async (projectKey, setToast) => {
         },
       });
 
-      console.log("fetchData", await fetchData.json());
-
       if (!fetchData.ok) {
-        setToast({ status: true, message: "Figma API 호출에 실패했습니다" });
+        setToast({ status: true, message: "Failed to call the Figma API." });
 
         return;
       }

--- a/src/utils/fetchImage.js
+++ b/src/utils/fetchImage.js
@@ -1,5 +1,6 @@
 const fetchImageUrl = async (projectKey, setToast) => {
-  const baseFigmaURL = `/v1/files/${projectKey}/images`;
+  const baseFigmaURL = `https://api.figma.com/v1/files/${projectKey}/images`;
+  
   const token = JSON.parse(localStorage.getItem("FigmaToken")).access_token;
 
   try {

--- a/src/utils/fetchImage.js
+++ b/src/utils/fetchImage.js
@@ -10,12 +10,16 @@ const fetchImageUrl = async (projectKey, setToast) => {
     }
 
     const fetchFrameImageURLs = async () => {
+      console.log("baseFigmaURL & token", baseFigmaURL, token);
+
       const fetchData = await fetch(baseFigmaURL, {
         method: "GET",
         headers: {
           Authorization: `Bearer ${token}`,
         },
       });
+
+      console.log("fetchData", await fetchData.json());
 
       if (!fetchData.ok) {
         setToast({ status: true, message: "Figma API 호출에 실패했습니다" });


### PR DESCRIPTION
## Fix (이슈 번호)
None

<br />

## 해결하려던 문제를 알려주세요!

- 문제 상황 :
배포 전 Fimga API로부터 정상적으로 받아오던 이미지 URL이 Netlify 배포후에 fetch 에러발생

|Fetch 에러 메세지|Network 요청 정보|
|---|---|
|![image](https://github.com/Figci/Figci-Client/assets/95596243/ff717d20-c238-45b3-b92c-a3f4ad2946ad)|![image](https://github.com/Figci/Figci-Client/assets/95596243/2aeaed51-2e55-40a8-8bbc-85f11b6d8e8d)|


<br />

## 어떻게 해결했나요?

- 문제 환경  :
Figma API로 부터 이미지 URI를 요청 시 CORS 에러 방지를 위해 vite.config.js에서 Proxy를 설정함
![image](https://github.com/Figci/Figci-Client/assets/95596243/60bd47df-a825-4d46-8e60-0035dcd008ac)

- 문제 원인 :
Netlify에 배포할때 vite.config.js에서  설정한 Proxy가 인식되지 않고 클라이언트의 주소로 요청 보냄.

- 문제 해결 :
```javascript
// 수정 전
const baseFigmaURL = `/v1/files/${projectKey}/images`;

// 수정 후
const PROXY = window.location.hostname === 'localhost' ? '' : '/proxy';
const baseFigmaURL = `${PROXY}/v1/files/${projectKey}/images`;
```

프로젝트 Root 경로에 netlfy.toml 파일에서 Proxy 설정을 추가함

참고 자료 :
[[netligy] 다른 서비스로 프록시](https://docs.netlify.com/routing/redirects/rewrites-proxies/)
[[velog] netlify로 배포시, proxy 셋팅하기](https://velog.io/@mochapoke/TIL-netlify%EB%A1%9C-%EB%B0%B0%ED%8F%AC%EC%8B%9C-proxy-%EC%85%8B%ED%8C%85%ED%95%98%EB%8A%94-%EB%B0%A9%EB%B2%95)
<br />

## 우려사항이 있나요?(선택사항)
특이사항 없습니다

<br />

## 잠깐! 확인해보셨나요?

- [X]  셀프 리뷰는 완료하셨나요?
- [X]  가장 최신 브랜치를 pull했나요?
- [X]  base 브랜치명을 확인하셨나요? (Front, Backend, feature 등)
- [X]  코드 컨벤션을 모두 지켰나요?
- [X]  적절한 라벨이 있나요?
- [X]  assignee가 있나요?
