### PR TITLE
Feature: Google Tag Manager 를 사용한 Googla Analytics 적용

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@
     new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
     j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-    })(window,document,'script','dataLayer','GTM-TVBPKSNR');
+    })(window,document,'script','dataLayer','%VITE_VITE_GOOGLE_TASK_MANAGER_ID%');
   </script>
   <!-- End Google Tag Manager -->
   <body>

--- a/index.html
+++ b/index.html
@@ -6,6 +6,15 @@
     <link rel="icon" href="/assets/favicon_figci.png" />
     <title>Figci</title>
   </head>
+  <!-- Google Tag Manager -->
+  <script>
+    (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','GTM-TVBPKSNR');
+  </script>
+  <!-- End Google Tag Manager -->
   <body>
     <div id="root"></div>
     <script type="module" src="/src/main.jsx"></script>

--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@
     new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
     j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-    })(window,document,'script','dataLayer','%VITE_VITE_GOOGLE_TASK_MANAGER_ID%');
+    })(window,document,'script','dataLayer','%VITE_GOOGLE_TASK_MANAGER_ID%');
   </script>
   <!-- End Google Tag Manager -->
   <body>

--- a/src/components/DiffingResult/index.jsx
+++ b/src/components/DiffingResult/index.jsx
@@ -95,16 +95,28 @@ function DiffingResult() {
 
     const newCanvas = initCanvas();
     newCanvas.on("mouse:wheel", ev => {
-      const delta = ev.e.deltaY;
-      let Zoom = canvasRef.current.getZoom();
-
-      Zoom *= 0.999 ** delta;
-      Zoom = Math.max(0.01, Math.min(20, Zoom));
-
-      canvasRef.current.zoomToPoint({ x: ev.e.offsetX, y: ev.e.offsetY }, Zoom);
-
       ev.e.preventDefault();
       ev.e.stopPropagation();
+
+      if (ev.e.ctrlKey) {
+        const delta = ev.e.deltaY;
+        let Zoom = canvasRef.current.getZoom();
+
+        Zoom *= 0.999 ** delta;
+        Zoom = Math.max(0.01, Math.min(30, Zoom));
+
+        canvasRef.current.zoomToPoint(
+          { x: ev.e.offsetX, y: ev.e.offsetY },
+          Zoom,
+        );
+      } else {
+        const viewport = canvasRef.current.viewportTransform;
+
+        viewport[4] += ev.e.deltaX;
+        viewport[5] += ev.e.deltaY;
+
+        canvasRef.current.requestRenderAll();
+      }
     });
 
     canvasRef.current = newCanvas;

--- a/src/components/DiffingResult/index.jsx
+++ b/src/components/DiffingResult/index.jsx
@@ -94,12 +94,14 @@ function DiffingResult() {
     };
 
     const newCanvas = initCanvas();
+
     newCanvas.on("mouse:wheel", ev => {
       ev.e.preventDefault();
       ev.e.stopPropagation();
 
       if (ev.e.ctrlKey) {
         const delta = ev.e.deltaY;
+
         let Zoom = canvasRef.current.getZoom();
 
         Zoom *= 0.999 ** delta;
@@ -266,6 +268,7 @@ function DiffingResult() {
               usingCase="line"
               handleClick={ev => {
                 ev.preventDefault();
+
                 setIsClickedNewVersion(false);
               }}
             >


### PR DESCRIPTION
## Fix (이슈 번호)

none

<br />

## 해결하려던 문제를 알려주세요!

1. Figci 홈페이지 사용자 추이를 확인하기 위해서 Figci 구글 계정에 Google Tag Manager를 등록 했습니다.
2. 비교페이지에서 Canvas Panning 기능을 추가했습니다. - 렌더된 디자인 요소를 좌우로 움직이거나 확대 / 축소 할 수 있습니다.

<br />

## 어떻게 해결했나요?

> Google Tag Manager ID 발급하였습니다.
> Google Analytics 계정 생성하였습니다.
위와 관련 내용은 보안 문제로 팀 슬랙에 공유하였습니다.

<br />

## 우려사항이 있나요?(선택사항)

> 추후에[ Google Task Assi](https://tagassistant.google.com/) 에서 사용자 이벤트를 추가해서 더욱 상세한 사용자의 홈페이지 사용 이력을 확인 할 수 있습니다. <br />Ex) 비교버튼 클릭 횟수, 비교 버전

<br />

## 잠깐! 확인해보셨나요?

- [x]  셀프 리뷰는 완료하셨나요?
- [x]  가장 최신 브랜치를 pull했나요?
- [x]  base 브랜치명을 확인하셨나요? (Front, Backend, feature 등)
- [x]  코드 컨벤션을 모두 지켰나요?
- [x]  적절한 라벨이 있나요?
- [x]  assignee가 있나요?

<br />

## Attachment(선택사항) 

| Netlify 에 환경변수에 GTM Id를 추가 | Canvas Panning 기능 추가 |
| ---- | ---- |
|![image](https://github.com/Figci/Figci-Client/assets/95596243/a8a8362a-5d51-451a-b743-1157aa7bfff9)|![panning](https://github.com/Figci/Figci-Client/assets/95596243/f78dcad4-7724-4331-90a2-be21de8eed22)|



<br />
