### PR TITLE
HOTFIX: 피그마URL 형식 변경에따른 수정

### DIFF
--- a/src/components/NewProject/index.jsx
+++ b/src/components/NewProject/index.jsx
@@ -43,7 +43,7 @@ function NewProject() {
 
   const isValidFigmaUrl = figmaUrl => {
     const figmaUrlPattern =
-      /^(?:https:\/\/)?(?:www\.)?figma\.com\/file\/([0-9a-zA-Z]{22,128})(?:\/?([^?]+)?(.*))?$/;
+      /^(?:https:\/\/)?(?:www\.)?figma\.com\/(?:file|design)\/([0-9a-zA-Z]{22,128})(?:\/([^?]+)?(\?.*)?)?$/;
 
     return figmaUrlPattern.test(figmaUrl);
   };


### PR DESCRIPTION
## Fix (이슈 번호)
None

<br />

## 해결하려던 문제를 알려주세요!
Figma에서 프로젝트 URL의 형식이 바뀜에 따라 기존 URL검증 로직의 수정이 필요했습니다.
- `기존 피그마 URL`
https://www.figma.com/file/wQ5CcLlM53WqoqcJhMgcfj/240123-Userflow-%2B-feature-detail?type=design&node-id=1-2&mode=design&t=C2z5aoERV5MPfL8B-11

- `CMD + L을 통해서 복사한 새로운URL 형식`
https://www.figma.com/design/wQ5CcLlM53WqoqcJhMgcfj/240123-Userflow-%2B-feature-detail?node-id=1-2&t=YgM9eEoypboIIzpp-11

<br />

## 어떻게 해결했나요?
`isValidFigmaUrl`함수 내부 로직의 정규표현식을 수정했습니다.

<br />

## 우려사항이 있나요?(선택사항)
없습니다!

<br />

## 잠깐! 확인해보셨나요?

- [X]  셀프 리뷰는 완료하셨나요?
- [X]  가장 최신 브랜치를 pull했나요?
- [X]  base 브랜치명을 확인하셨나요? (Front, Backend, feature 등)
- [X]  코드 컨벤션을 모두 지켰나요?
- [X]  적절한 라벨이 있나요?
- [X]  assignee가 있나요?