### PR TITLE
Fix: 반응형에 따른 UI 수정

### DIFF
--- a/src/components/DiffingResult/index.jsx
+++ b/src/components/DiffingResult/index.jsx
@@ -275,7 +275,7 @@ function DiffingResult() {
       {isClickedNewVersion && (
         <Modal>
           <TextWrapper>
-            <h1 className="re-version-title">Compare a new project?</h1>
+            <h1 className="re-version-title">Compare a new version?</h1>
             <Description
               className="re-version-description"
               size="medium"

--- a/src/components/DiffingResult/index.jsx
+++ b/src/components/DiffingResult/index.jsx
@@ -395,25 +395,25 @@ function DiffingResult() {
 const PaginationButton = styled.img`
   position: absolute;
   top: 50%;
-  ${({ direction }) => (direction === "left" ? "left: 10px;" : "right: 10px;")}
+  ${({ direction }) => (direction === "left" ? "left: 24px;" : "right: 24px;")}
   transform: translateY(-50%);
 
-  width: 40px;
-  height: 40px;
+  width: 48px;
+  height: 48px;
 
   cursor: pointer;
 `;
 
 const PaginationWrapper = styled.div`
   position: absolute;
-  bottom: 20px;
-  right: 20px;
+  bottom: 30px;
+  right: 30px;
 
   padding: 10px 20px;
-
-  background-color: #000000;
-  color: #ffffff;
   border-radius: 20px;
+
+  background-color: rgba(0, 0, 0, 0.7);
+  color: #ffffff;
   font-size: 16px;
   font-weight: bold;
 `;

--- a/src/components/DiffingResult/index.jsx
+++ b/src/components/DiffingResult/index.jsx
@@ -84,9 +84,9 @@ function DiffingResult() {
   const beforeVersionLabel = getVersionLabel(beforeDate, beforeVersion);
   const afterVersionLabel = getVersionLabel(afterDate, afterVersion);
 
-  const handleClickPagination = e => {
-    const direction = e.currentTarget.getAttribute("direction");
-    const offsetIndex = direction === "left" ? 1 : frameList.length - 1;
+  const handleClickPagination = ev => {
+    const direction = ev.currentTarget.getAttribute("direction");
+    const offsetIndex = direction === "left" ? frameList.length - 1 : 1;
     const nextIndex = (currentPage + offsetIndex) % frameList.length;
 
     changeFrame(nextIndex);

--- a/src/components/NewProject/index.jsx
+++ b/src/components/NewProject/index.jsx
@@ -111,7 +111,6 @@ function NewProject() {
           <Welcome handleClick={handleModalClick} />
         </Modal>
       )}
-      l
       <ContentsWrapper>
         <form onSubmit={handleSubmitURI}>
           <Title title={contents.title} />
@@ -142,7 +141,8 @@ const ContentsWrapper = styled.div`
 
   input {
     display: flex;
-    width: 560px;
+    width: 100%;
+    max-width: 560px;
     height: 64px;
     padding: 0px 24px;
     border-radius: 8px;

--- a/src/components/shared/Select.jsx
+++ b/src/components/shared/Select.jsx
@@ -64,7 +64,7 @@ const SelectWrapper = styled.div`
 
   .description {
     display: block;
-    width: 500px;
+    width: 100%;
 
     color: #868e96;
     font-size: 1rem;

--- a/src/components/shared/Title.jsx
+++ b/src/components/shared/Title.jsx
@@ -27,7 +27,7 @@ const TitleWrapper = styled.div`
   }
 
   .spacing {
-    white-space: pre;
+    white-space: pre-wrap;
   }
 `;
 


### PR DESCRIPTION
## Fix (이슈 번호)
None

<br />

## 해결하려던 문제를 알려주세요!
1. `NewProject`, `ProjectPage`컴포넌트 내부 요소들이 반응형에 대응되지 못하고 있었습니다.
2. 페이지네이션이 클릭한 방향과 반대로 동작하고 있었습니다.
3. DiffingResult에서 `새로운 버전 비교` 버튼 클릭시 **_"새로운 버전을 비교하시겠습니까?"_** 대신 **_"새로운 프로젝트를 비교하시겠습니까?"_** 로 나오고 있었습니다.

<br />

## 어떻게 해결했나요?
- 컴포넌트 내부 input의 너비를 `px`에서 `%`로 수정했습니다.
- description너비 또한 `px`에서 `%`로 수정했습니다.
- `Title컴포넌트`의 white-space를 `pre-wrap`으로 수정했습니다.
- pagination의 `left`를 클릭했을 때 프레임 길이에서 -1 해주도록 수정했습니다.
(left를 클릭했을 때 랑 right를 클릭했을 때 의 로직을 서로 바꿔주었습니다)

<br />

## 우려사항이 있나요?(선택사항)
특이사항 없습니다.

<br />

## 잠깐! 확인해보셨나요?

- [X]  셀프 리뷰는 완료하셨나요?
- [X]  가장 최신 브랜치를 pull했나요?
- [X]  base 브랜치명을 확인하셨나요? (Front, Backend, feature 등)
- [X]  코드 컨벤션을 모두 지켰나요?
- [X]  적절한 라벨이 있나요?
- [X]  assignee가 있나요?

<br />

## Attachment(선택사항) 

![ProjectPage 반응형](https://github.com/Figci/Figci-Client/assets/48385389/4cfc3f1f-6b15-4fec-8a66-eef5b6e625fb)
→ ProjectPage 반응형 대응

<br />

![DiffingResult 개선 화면](https://github.com/Figci/Figci-Client/assets/48385389/50edb646-d20a-4299-8ba3-69c786889033)
→ DiffingResult 개선 화면
